### PR TITLE
fix: [KAN-35] daily todo 년 월로 조회

### DIFF
--- a/src/hb-backend-api/category/adapters/in/rest/category.controller.ts
+++ b/src/hb-backend-api/category/adapters/in/rest/category.controller.ts
@@ -66,6 +66,7 @@ export class CategoryController {
   }
 
   @ApiOperation({ description: "카테고리 단건 조회" })
+  @ApiParam({ name: "id", type: String })
   @UseGuards(JwtAuthGuard)
   @Get(":id")
   public async getOne(

--- a/src/hb-backend-api/daily-todo/adapters/in/dto/get-daily-todo.dto.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/dto/get-daily-todo.dto.ts
@@ -1,6 +1,6 @@
 import { DailyTodoCompleteStatus } from "../../../domain/enums/daily-todo-complete-status.enum";
 import { DailyTodoCycle } from "../../../domain/enums/daily-todo-cycle.enum";
-import { DailyTodoWithRelationQueryResult } from "../../../application/ports/out/daily-todo-query.result";
+import { DailyTodoWithRelationQueryResult } from "../../../application/result/daily-todo-query.result";
 
 interface OwnerType {
   id: string;

--- a/src/hb-backend-api/daily-todo/adapters/in/pipe/year-month-day-string.pipe.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/pipe/year-month-day-string.pipe.ts
@@ -1,0 +1,10 @@
+import { PipeTransform } from "@nestjs/common";
+import { YearMonthDayString } from "../../../domain/vo/year-month-day-string.vo";
+
+export class ParseYearMonthDayStringPipe
+  implements PipeTransform<string, YearMonthDayString>
+{
+  transform(value: string): YearMonthDayString {
+    return YearMonthDayString.fromString(value);
+  }
+}

--- a/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
@@ -7,7 +7,7 @@ import {
   Post,
   UseGuards,
 } from "@nestjs/common";
-import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiOperation, ApiParam, ApiTags } from "@nestjs/swagger";
 import { DIToken } from "../../../../../shared/di/token.di";
 import { CreateDailyTodoUseCase } from "../../../application/ports/in/create-daily-todo.use-case";
 import { JwtAuthGuard } from "../../../../../shared/adpaters/in/rest/guard/jwt-auth.guard";
@@ -40,6 +40,7 @@ export class DailyTodoController {
   ) {}
 
   @ApiOperation({ description: "데일리 투두 모두 조회" })
+  @ApiParam({ name: "date", type: String })
   @UseGuards(JwtAuthGuard)
   @Get(":date")
   public async findAll(

--- a/src/hb-backend-api/daily-todo/adapters/out/query/daily-todo-query.adapter.ts
+++ b/src/hb-backend-api/daily-todo/adapters/out/query/daily-todo-query.adapter.ts
@@ -12,6 +12,7 @@ import {
 import { CategoryId } from "../../../../category/domain/vo/category-id.vo";
 import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
 import { ObjectHelper } from "../../../../../shared/object/object.helper";
+import { YearMonthDayString } from "../../../domain/vo/year-month-day-string.vo";
 
 @Injectable()
 export class DailyTodoQueryAdapter implements DailyTodoQueryPort {
@@ -20,8 +21,11 @@ export class DailyTodoQueryAdapter implements DailyTodoQueryPort {
     private readonly dailyTodoRepository: DailyTodoRepository,
   ) {}
 
-  public async findAll(owner: UserId): Promise<DailyTodoWithRelationEntity[]> {
-    const dailyTodos = await this.dailyTodoRepository.findAll(owner);
+  public async findAll(
+    owner: UserId,
+    date: YearMonthDayString,
+  ): Promise<DailyTodoWithRelationEntity[]> {
+    const dailyTodos = await this.dailyTodoRepository.findAll(owner, date);
 
     return dailyTodos.map(this.toRelationEntity);
   }

--- a/src/hb-backend-api/daily-todo/application/ports/in/get-all-daily-todo.use-case.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/in/get-all-daily-todo.use-case.ts
@@ -1,6 +1,10 @@
 import { UserId } from "../../../../user/domain/vo/user-id.vo";
-import { DailyTodoWithRelationQueryResult } from "../out/daily-todo-query.result";
+import { DailyTodoWithRelationQueryResult } from "../../result/daily-todo-query.result";
+import { YearMonthDayString } from "../../../domain/vo/year-month-day-string.vo";
 
 export interface GetAllDailyTodoUseCase {
-  invoke(owner: UserId): Promise<DailyTodoWithRelationQueryResult[]>;
+  invoke(
+    owner: UserId,
+    date: YearMonthDayString,
+  ): Promise<DailyTodoWithRelationQueryResult[]>;
 }

--- a/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-query.port.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-query.port.ts
@@ -1,6 +1,10 @@
 import { UserId } from "../../../../user/domain/vo/user-id.vo";
 import { DailyTodoWithRelationEntity } from "../../../domain/entity/daily-todo.retations";
+import { YearMonthDayString } from "../../../domain/vo/year-month-day-string.vo";
 
 export interface DailyTodoQueryPort {
-  findAll(owner: UserId): Promise<DailyTodoWithRelationEntity[]>;
+  findAll(
+    owner: UserId,
+    date: YearMonthDayString,
+  ): Promise<DailyTodoWithRelationEntity[]>;
 }

--- a/src/hb-backend-api/daily-todo/application/result/daily-todo-query.result.ts
+++ b/src/hb-backend-api/daily-todo/application/result/daily-todo-query.result.ts
@@ -1,11 +1,11 @@
-import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
-import { DailyTodoCompleteStatus } from "../../../domain/enums/daily-todo-complete-status.enum";
-import { DailyTodoCycle } from "../../../domain/enums/daily-todo-cycle.enum";
+import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
+import { DailyTodoCompleteStatus } from "../../domain/enums/daily-todo-complete-status.enum";
+import { DailyTodoCycle } from "../../domain/enums/daily-todo-cycle.enum";
 import {
   Category,
   DailyTodoWithRelationEntity,
   Owner,
-} from "../../../domain/entity/daily-todo.retations";
+} from "../../domain/entity/daily-todo.retations";
 
 export class DailyTodoWithRelationQueryResult {
   constructor(

--- a/src/hb-backend-api/daily-todo/application/use-cases/get-all-daily-todo.service.ts
+++ b/src/hb-backend-api/daily-todo/application/use-cases/get-all-daily-todo.service.ts
@@ -4,7 +4,8 @@ import { DIToken } from "../../../../shared/di/token.di";
 import { DailyTodoQueryPort } from "../ports/out/daily-todo-query.port";
 import { DailyTodoWithRelationEntity } from "../../domain/entity/daily-todo.retations";
 import { UserId } from "../../../user/domain/vo/user-id.vo";
-import { DailyTodoWithRelationQueryResult } from "../ports/out/daily-todo-query.result";
+import { DailyTodoWithRelationQueryResult } from "../result/daily-todo-query.result";
+import { YearMonthDayString } from "../../domain/vo/year-month-day-string.vo";
 
 @Injectable()
 export class GetAllDailyTodoService implements GetAllDailyTodoUseCase {
@@ -15,13 +16,17 @@ export class GetAllDailyTodoService implements GetAllDailyTodoUseCase {
 
   public async invoke(
     owner: UserId,
+    date: YearMonthDayString,
   ): Promise<DailyTodoWithRelationQueryResult[]> {
-    const dailyTodos = await this.findAll(owner);
+    const dailyTodos = await this.findAll(owner, date);
 
     return dailyTodos.map(DailyTodoWithRelationQueryResult.from);
   }
 
-  private async findAll(owner: UserId): Promise<DailyTodoWithRelationEntity[]> {
-    return await this.dailyTodoQueryPort.findAll(owner);
+  private async findAll(
+    owner: UserId,
+    date: YearMonthDayString,
+  ): Promise<DailyTodoWithRelationEntity[]> {
+    return await this.dailyTodoQueryPort.findAll(owner, date);
   }
 }

--- a/src/hb-backend-api/daily-todo/domain/entity/daily-todo.entity.ts
+++ b/src/hb-backend-api/daily-todo/domain/entity/daily-todo.entity.ts
@@ -15,10 +15,10 @@ export class DailyTodoEntity extends BaseEntity {
   title: string;
 
   @Prop({
-    type: String,
+    type: Date,
     required: true,
   })
-  date: string;
+  date: Date;
 
   @Prop({
     type: Types.ObjectId,

--- a/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
+++ b/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
@@ -1,9 +1,13 @@
 import { DailyTodoCreateEntitySchema } from "../entity/daily-todo.entity";
 import { UserId } from "../../../user/domain/vo/user-id.vo";
 import type { DailyTodoWithRelations } from "../entity/daily-todo.retations";
+import { YearMonthDayString } from "../vo/year-month-day-string.vo";
 
 export interface DailyTodoRepository {
   save(dailyTodoCreateSchemaEntity: DailyTodoCreateEntitySchema): Promise<void>;
 
-  findAll(owner: UserId): Promise<DailyTodoWithRelations[]>;
+  findAll(
+    owner: UserId,
+    date: YearMonthDayString,
+  ): Promise<DailyTodoWithRelations[]>;
 }

--- a/src/hb-backend-api/daily-todo/domain/vo/year-month-day-string.vo.ts
+++ b/src/hb-backend-api/daily-todo/domain/vo/year-month-day-string.vo.ts
@@ -1,0 +1,57 @@
+import { BadRequestException } from "@nestjs/common";
+import { DateHelper } from "../../../../shared/date/date.helper";
+
+export class YearMonthDayString {
+  private readonly _value: string;
+  private readonly _year: number;
+  private readonly _month: number;
+  private readonly _day: number;
+
+  constructor(dateStr: string) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+      throw new BadRequestException(
+        `날짜 형식이 올바르지 않아요. (YYYY-MM-DD): ${dateStr}`,
+      );
+    }
+
+    const [yearStr, monthStr, dayStr] = dateStr.split("-");
+    const year = Number(yearStr);
+    const month = Number(monthStr);
+    const day = Number(dayStr);
+
+    const date = new Date(dateStr);
+    if (
+      !DateHelper.isValid(date) ||
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() + 1 !== month ||
+      date.getUTCDate() !== day
+    ) {
+      throw new BadRequestException(`존재하지 않는 날짜에요. ${dateStr}`);
+    }
+
+    this._value = dateStr;
+    this._year = year;
+    this._month = month;
+    this._day = day;
+  }
+
+  public static fromString(dateStr: string): YearMonthDayString {
+    return new YearMonthDayString(dateStr);
+  }
+
+  public get value(): string {
+    return this._value;
+  }
+
+  public get year(): number {
+    return this._year;
+  }
+
+  public get month(): number {
+    return this._month;
+  }
+
+  public get day(): number {
+    return this._day;
+  }
+}

--- a/src/shared/date/date.helper.ts
+++ b/src/shared/date/date.helper.ts
@@ -46,23 +46,45 @@ export class DateHelper {
     );
   }
 
+  public static startOfMonth(date: Date): Date {
+    date.setDate(1);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  public static endOfMonth(date: Date): Date {
+    const month = date.getMonth();
+    date.setFullYear(date.getFullYear(), month + 1, 0);
+    date.setHours(23, 59, 59, 999);
+    return date;
+  }
+
   public static isValid(date: unknown): boolean {
     return date instanceof Date && !isNaN(date.getTime());
   }
 
-  public static parse(dateStr: string): Date {
+  public static parse(dateStr: string, timezone: "KST" | "UTC" = "UTC"): Date {
     const regex = /^\d{4}-\d{2}-\d{2}$/;
     if (!regex.test(dateStr)) {
       throw new Error("Invalid date string");
     }
 
     const [year, month, day] = dateStr.split("-").map(Number);
-    const parsed = new Date(year, month - 1, day);
-    if (
-      parsed.getFullYear() !== year ||
-      parsed.getMonth() !== month - 1 ||
-      parsed.getDate() !== day
-    ) {
+
+    let parsed: Date;
+
+    if (timezone === "KST") {
+      parsed = new Date(Date.UTC(year, month - 1, day, 15, 0, 0));
+    } else {
+      parsed = new Date(year, month - 1, day);
+    }
+
+    const y =
+      timezone === "KST" ? parsed.getUTCFullYear() : parsed.getFullYear();
+    const m = timezone === "KST" ? parsed.getUTCMonth() : parsed.getMonth();
+    const d = timezone === "KST" ? parsed.getUTCDate() : parsed.getDate();
+
+    if (y !== year || m !== month - 1 || d !== day) {
       throw new Error("Invalid date");
     }
 

--- a/test/shared/date/date.helper.spec.ts
+++ b/test/shared/date/date.helper.spec.ts
@@ -61,6 +61,49 @@ describe("DateHelper", () => {
     });
   });
 
+  describe("startOfMonth", () => {
+    it("should return the first day of the month at 00:00:00.000", () => {
+      const inputDate = new Date("2025-05-22T15:30:45.123Z");
+      const result = DateHelper.startOfMonth(new Date(inputDate)); // 원본 훼손 방지 위해 복사본 사용
+
+      expect(result.getDate()).toBe(1);
+      expect(result.getHours()).toBe(0);
+      expect(result.getMinutes()).toBe(0);
+      expect(result.getSeconds()).toBe(0);
+      expect(result.getMilliseconds()).toBe(0);
+      expect(result.getMonth()).toBe(inputDate.getMonth());
+      expect(result.getFullYear()).toBe(inputDate.getFullYear());
+    });
+  });
+
+  describe("endOfMonth", () => {
+    it("should return the last day of the month at 23:59:59.999", () => {
+      const inputDate = new Date("2025-05-22T15:30:45.123Z");
+      const result = DateHelper.endOfMonth(new Date(inputDate));
+
+      expect(result.getDate()).toBe(31);
+      expect(result.getHours()).toBe(23);
+      expect(result.getMinutes()).toBe(59);
+      expect(result.getSeconds()).toBe(59);
+      expect(result.getMilliseconds()).toBe(999);
+      expect(result.getMonth()).toBe(inputDate.getMonth());
+      expect(result.getFullYear()).toBe(inputDate.getFullYear());
+    });
+
+    it("should handle December correctly and roll over to next year", () => {
+      const inputDate = new Date("2025-12-15T10:00:00Z");
+      const result = DateHelper.endOfMonth(new Date(inputDate));
+
+      expect(result.getMonth()).toBe(11); // 0-based, 11 = December
+      expect(result.getDate()).toBe(31);
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getHours()).toBe(23);
+      expect(result.getMinutes()).toBe(59);
+      expect(result.getSeconds()).toBe(59);
+      expect(result.getMilliseconds()).toBe(999);
+    });
+  });
+
   describe("isValid()", () => {
     it("should return true for valid Date", () => {
       expect(DateHelper.isValid(new Date())).toBe(true);


### PR DESCRIPTION
## 🚀 Summary

년월로 조회 가능하도록 수정

- 목적: 리팩토링

---

## 📸 Screenshots / API Contract (옵션)

- (선택 사항) Swagger 변경 요약 / 스크린샷 / Postman 스냅샷 링크 첨부

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (Y)
- 환경 변수 추가/변경: (Y)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
