### PR TITLE
feat: [KAN-36] daily todo ID 단건 조회

### DIFF
--- a/src/hb-backend-api/daily-todo/adapters/in/pipe/daily-todo-id.pipe.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/pipe/daily-todo-id.pipe.ts
@@ -1,0 +1,10 @@
+import { PipeTransform } from "@nestjs/common";
+import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
+
+export class ParseDailyTodoIdPipe
+  implements PipeTransform<string, DailyTodoId>
+{
+  transform(value: string): DailyTodoId {
+    return DailyTodoId.fromString(value);
+  }
+}

--- a/src/hb-backend-api/daily-todo/adapters/out/aggregation/daily-todo-aggregation.helper.ts
+++ b/src/hb-backend-api/daily-todo/adapters/out/aggregation/daily-todo-aggregation.helper.ts
@@ -42,4 +42,28 @@ export class DailyTodoAggregationHelper {
       },
     ];
   }
+
+  public static buildProject(): PipelineStage[] {
+    return [
+      {
+        $project: {
+          id: "$_id",
+          title: 1,
+          date: 1,
+          reaction: 1,
+          progress: 1,
+          cycle: 1,
+          owner: {
+            id: "$owner._id",
+            username: "$owner.username",
+            nickname: "$owner.nickname",
+          },
+          category: {
+            id: "$category._id",
+            title: "$category.title",
+          },
+        },
+      },
+    ];
+  }
 }

--- a/src/hb-backend-api/daily-todo/adapters/out/query/daily-todo-query.adapter.ts
+++ b/src/hb-backend-api/daily-todo/adapters/out/query/daily-todo-query.adapter.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { DailyTodoQueryPort } from "../../../application/ports/out/daily-todo-query.port";
 import { DIToken } from "../../../../../shared/di/token.di";
 import { DailyTodoRepository } from "../../../domain/repositories/daily-todo.repository";
@@ -28,6 +28,20 @@ export class DailyTodoQueryAdapter implements DailyTodoQueryPort {
     const dailyTodos = await this.dailyTodoRepository.findAll(owner, date);
 
     return dailyTodos.map(this.toRelationEntity);
+  }
+
+  public async findById(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationEntity> {
+    const dailyTodo = await this.dailyTodoRepository.findById(id, owner);
+    if (dailyTodo == null) {
+      throw new NotFoundException(
+        `해당하는 데일리 투두가 없어요. ID: ${id.toString()}`,
+      );
+    }
+
+    return this.toRelationEntity(dailyTodo);
   }
 
   private toRelationEntity(

--- a/src/hb-backend-api/daily-todo/application/ports/in/get-daily-todo.use-case.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/in/get-daily-todo.use-case.ts
@@ -1,0 +1,10 @@
+import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
+import { UserId } from "../../../../user/domain/vo/user-id.vo";
+import { DailyTodoWithRelationQueryResult } from "../../result/daily-todo-query.result";
+
+export interface GetDailyTodoUseCase {
+  invoke(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationQueryResult>;
+}

--- a/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-query.port.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-query.port.ts
@@ -1,10 +1,16 @@
 import { UserId } from "../../../../user/domain/vo/user-id.vo";
 import { DailyTodoWithRelationEntity } from "../../../domain/entity/daily-todo.retations";
 import { YearMonthDayString } from "../../../domain/vo/year-month-day-string.vo";
+import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
 
 export interface DailyTodoQueryPort {
   findAll(
     owner: UserId,
     date: YearMonthDayString,
   ): Promise<DailyTodoWithRelationEntity[]>;
+
+  findById(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationEntity>;
 }

--- a/src/hb-backend-api/daily-todo/application/use-cases/get-daily-todo.service.ts
+++ b/src/hb-backend-api/daily-todo/application/use-cases/get-daily-todo.service.ts
@@ -1,0 +1,32 @@
+import { GetDailyTodoUseCase } from "../ports/in/get-daily-todo.use-case";
+import { Inject, Injectable } from "@nestjs/common";
+import { DIToken } from "../../../../shared/di/token.di";
+import { DailyTodoQueryPort } from "../ports/out/daily-todo-query.port";
+import { UserId } from "src/hb-backend-api/user/domain/vo/user-id.vo";
+import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
+import { DailyTodoWithRelationQueryResult } from "../result/daily-todo-query.result";
+import { DailyTodoWithRelationEntity } from "../../domain/entity/daily-todo.retations";
+
+@Injectable()
+export class GetDailyTodoService implements GetDailyTodoUseCase {
+  constructor(
+    @Inject(DIToken.DailyTodoModule.DailyTodoQueryPort)
+    private readonly dailyTodoQueryPort: DailyTodoQueryPort,
+  ) {}
+
+  public async invoke(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationQueryResult> {
+    const dailyTodo = await this.findById(id, owner);
+
+    return DailyTodoWithRelationQueryResult.from(dailyTodo);
+  }
+
+  private async findById(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationEntity> {
+    return await this.dailyTodoQueryPort.findById(id, owner);
+  }
+}

--- a/src/hb-backend-api/daily-todo/daily-todo.module.ts
+++ b/src/hb-backend-api/daily-todo/daily-todo.module.ts
@@ -10,6 +10,7 @@ import { DailyTodoPersistenceAdapter } from "./adapters/out/persistence/daily-to
 import { CreateDailyTodoService } from "./application/use-cases/create-daily-todo.service";
 import { DailyTodoQueryAdapter } from "./adapters/out/query/daily-todo-query.adapter";
 import { GetAllDailyTodoService } from "./application/use-cases/get-all-daily-todo.service";
+import { GetDailyTodoService } from "./application/use-cases/get-daily-todo.service";
 
 @Module({
   imports: [
@@ -42,6 +43,10 @@ import { GetAllDailyTodoService } from "./application/use-cases/get-all-daily-to
       provide: DIToken.DailyTodoModule.GetAllDailyTodoUseCase,
       useClass: GetAllDailyTodoService,
     },
+    {
+      provide: DIToken.DailyTodoModule.GetDailyTodoUseCase,
+      useClass: GetDailyTodoService,
+    },
   ],
   controllers: [DailyTodoController],
   exports: [
@@ -51,6 +56,7 @@ import { GetAllDailyTodoService } from "./application/use-cases/get-all-daily-to
     DIToken.DailyTodoModule.DailyTodoQueryPort,
     DIToken.DailyTodoModule.CreateDailyTodoUseCase,
     DIToken.DailyTodoModule.GetAllDailyTodoUseCase,
+    DIToken.DailyTodoModule.GetDailyTodoUseCase,
   ],
 })
 export class DailyTodoModule {}

--- a/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
+++ b/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
@@ -2,6 +2,7 @@ import { DailyTodoCreateEntitySchema } from "../entity/daily-todo.entity";
 import { UserId } from "../../../user/domain/vo/user-id.vo";
 import type { DailyTodoWithRelations } from "../entity/daily-todo.retations";
 import { YearMonthDayString } from "../vo/year-month-day-string.vo";
+import { DailyTodoId } from "../vo/daily-todo-id.vo";
 
 export interface DailyTodoRepository {
   save(dailyTodoCreateSchemaEntity: DailyTodoCreateEntitySchema): Promise<void>;
@@ -10,4 +11,9 @@ export interface DailyTodoRepository {
     owner: UserId,
     date: YearMonthDayString,
   ): Promise<DailyTodoWithRelations[]>;
+
+  findById(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelations | null>;
 }

--- a/src/hb-backend-api/daily-todo/infra/repositories/daily-todo.repository.impl.ts
+++ b/src/hb-backend-api/daily-todo/infra/repositories/daily-todo.repository.impl.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { Model } from "mongoose";
 import { DailyTodoDocument } from "../../domain/entity/daily-todo.schema";
@@ -7,14 +7,21 @@ import {
   DailyTodoEntity,
 } from "../../domain/entity/daily-todo.entity";
 import { DailyTodoRepository } from "../../domain/repositories/daily-todo.repository";
-import { UserId } from "src/hb-backend-api/user/domain/vo/user-id.vo";
 import { DailyTodoAggregationHelper } from "../../adapters/out/aggregation/daily-todo-aggregation.helper";
 import type { DailyTodoWithRelations } from "../../domain/entity/daily-todo.retations";
 import { YearMonthDayString } from "../../domain/vo/year-month-day-string.vo";
 import { DateHelper } from "../../../../shared/date/date.helper";
+import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
+import { AggregateQuery } from "../../../../infra/mongo/query/aggregate.query";
+import { UserId } from "../../../user/domain/vo/user-id.vo";
 
 @Injectable()
 export class DailyTodoRepositoryImpl implements DailyTodoRepository {
+  private readonly TTL_MS = 30_000;
+  private readonly aggregateQuery = AggregateQuery.of<DailyTodoWithRelations>(
+    this.TTL_MS,
+  );
+
   constructor(
     @InjectModel(DailyTodoEntity.name)
     private readonly dailyTodoModel: Model<DailyTodoDocument>,
@@ -45,44 +52,41 @@ export class DailyTodoRepositoryImpl implements DailyTodoRepository {
     endDate.setMonth(endDate.getMonth() + 1);
     const endOfMonth = DateHelper.startOfMonth(endDate);
 
-    const dailyTodos = await this.dailyTodoModel
-      .aggregate([
-        {
-          $match: {
-            owner: owner.raw,
-            date: {
-              $gte: startOfMonth,
-              $lte: endOfMonth,
+    return this.aggregateQuery.fetchAll(
+      `daily-todos:${owner.toString()}:${date.value}`,
+      () =>
+        this.dailyTodoModel
+          .aggregate([
+            {
+              $match: {
+                owner: owner.raw,
+                date: { $gte: startOfMonth, $lte: endOfMonth },
+              },
             },
-          },
-        },
-        ...DailyTodoAggregationHelper.buildUserJoin(),
-        ...DailyTodoAggregationHelper.buildCategoryJoin(),
-        {
-          $project: {
-            id: "$_id",
-            title: 1,
-            date: 1,
-            reaction: 1,
-            progress: 1,
-            cycle: 1,
-            owner: {
-              id: "$owner._id",
-              username: "$owner.username",
-              nickname: "$owner.nickname",
-            },
-            category: {
-              id: "$category._id",
-              title: "$category.title",
-            },
-          },
-        },
-      ])
-      .exec();
-    if (dailyTodos == null) {
-      return [];
-    }
+            ...DailyTodoAggregationHelper.buildUserJoin(),
+            ...DailyTodoAggregationHelper.buildCategoryJoin(),
+            ...DailyTodoAggregationHelper.buildProject(),
+          ])
+          .exec(),
+    );
+  }
 
-    return dailyTodos;
+  public async findById(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelations | null> {
+    return this.aggregateQuery.fetch(
+      `daily-todo:${id.toString()}:${owner.toString()}`,
+      () =>
+        this.dailyTodoModel
+          .aggregate([
+            { $match: { _id: id.raw, owner: owner.raw } },
+            ...DailyTodoAggregationHelper.buildUserJoin(),
+            ...DailyTodoAggregationHelper.buildCategoryJoin(),
+            ...DailyTodoAggregationHelper.buildProject(),
+            { $limit: 1 },
+          ])
+          .exec(),
+    );
   }
 }

--- a/src/infra/cache/memory.cache.ts
+++ b/src/infra/cache/memory.cache.ts
@@ -1,0 +1,53 @@
+export class MemoryCache<T> {
+  private store = new Map<string, { value: T | T[]; expires: number }>();
+
+  constructor(
+    private ttlMs: number = 30000,
+    private readonly maxEntries: number = 1000,
+  ) {
+    this.maxEntries = maxEntries;
+  }
+
+  public static of<T>(
+    ttlMs: number = 30000,
+    maxEntries: number = 1000,
+  ): MemoryCache<T> {
+    return new MemoryCache<T>(ttlMs, maxEntries);
+  }
+
+  public get(key: string): T | T[] | null {
+    const entry = this.store.get(key);
+    if (entry == null || entry.expires < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+
+    // LRU -> ( Lease Recently Used )
+    this.store.delete(key);
+    this.store.set(key, entry);
+
+    return entry.value;
+  }
+
+  public set(key: string, value: T | T[]): void {
+    if (this.store.size >= this.maxEntries) {
+      // LRU delete
+      const oldestKey = String(this.store.keys().next().value);
+      this.store.delete(oldestKey);
+    }
+
+    this.store.set(key, { value, expires: Date.now() + this.ttlMs });
+  }
+
+  public setTTLMs(ttlMs: number): void {
+    this.ttlMs = ttlMs;
+  }
+
+  public invalidate(key: string): void {
+    this.store.delete(key);
+  }
+
+  public clear(): void {
+    this.store.clear();
+  }
+}

--- a/src/infra/mongo/query/aggregate-result.query.ts
+++ b/src/infra/mongo/query/aggregate-result.query.ts
@@ -1,0 +1,23 @@
+export class AggregateResultQuery {
+  public static async fetchSingleResult<T>(
+    aggregateQuery: Promise<T[]>,
+  ): Promise<T | null> {
+    const result = await aggregateQuery;
+    if (result == null || result.length === 0) {
+      return null;
+    }
+
+    return result[0];
+  }
+
+  public static async fetchMultipleResult<T>(
+    aggregateQuery: Promise<T[]>,
+  ): Promise<T[]> {
+    const result = await aggregateQuery;
+    if (result == null || result.length === 0) {
+      return [];
+    }
+
+    return result;
+  }
+}

--- a/src/infra/mongo/query/aggregate.query.ts
+++ b/src/infra/mongo/query/aggregate.query.ts
@@ -1,0 +1,50 @@
+import { MemoryCache } from "../../cache/memory.cache";
+import { AggregateResultQuery } from "./aggregate-result.query";
+
+export class AggregateQuery<T> {
+  private memoryCache: MemoryCache<T | T[]> = MemoryCache.of<T | T[]>();
+
+  constructor() {}
+
+  public static of<T>(ttlMs: number = 30000): AggregateQuery<T> {
+    const query = new AggregateQuery<T>();
+    query.memoryCache.setTTLMs(ttlMs);
+
+    return query;
+  }
+
+  public async fetch(
+    key: string,
+    aggregateQuery: () => Promise<T[]>,
+  ): Promise<T | null> {
+    const cached = this.memoryCache.get(key);
+    if (cached != null) {
+      return cached as T;
+    }
+
+    const result =
+      await AggregateResultQuery.fetchSingleResult(aggregateQuery());
+    if (result == null) {
+      return null;
+    }
+    this.memoryCache.set(key, result);
+
+    return result;
+  }
+
+  public async fetchAll(
+    key: string,
+    aggregateQuery: () => Promise<T[]>,
+  ): Promise<T[]> {
+    const cached = this.memoryCache.get(key);
+    if (cached != null) {
+      return cached as T[];
+    }
+
+    const result =
+      await AggregateResultQuery.fetchMultipleResult(aggregateQuery());
+    this.memoryCache.set(key, result);
+
+    return result;
+  }
+}

--- a/src/shared/di/token.di.ts
+++ b/src/shared/di/token.di.ts
@@ -1,5 +1,6 @@
 import { DITokenRegister } from "./token-registry.di";
 import { GetAllDailyTodoUseCase } from "../../hb-backend-api/daily-todo/application/ports/in/get-all-daily-todo.use-case";
+import { GetDailyTodoUseCase } from "../../hb-backend-api/daily-todo/application/ports/in/get-daily-todo.use-case";
 
 export class DIToken {
   public static readonly AuthModule = class extends DITokenRegister {
@@ -64,5 +65,6 @@ export class DIToken {
     public static GetAllDailyTodoUseCase = this.register(
       "GetAllDailyTodoUseCase",
     );
+    public static GetDailyTodoUseCase = this.register("GetDailyTodoUseCase");
   };
 }

--- a/test/mocks/daily-todo.repository.mock.ts
+++ b/test/mocks/daily-todo.repository.mock.ts
@@ -4,5 +4,6 @@ export function createDailyTodoRepository(): jest.Mocked<DailyTodoRepository> {
   return {
     save: jest.fn(),
     findAll: jest.fn(),
+    findById: jest.fn(),
   };
 }


### PR DESCRIPTION
## 🚀 Summary
메모리 캐시 LRU 적용
daily todo 단건 조회

- 목적: 기능 추가

---

## 📸 Screenshots / API Contract (옵션)

<img width="1561" alt="image" src="https://github.com/user-attachments/assets/f0a2543b-4b9e-4a7a-a6e2-7f56031ca2c6" />

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (Y)
- 환경 변수 추가/변경: (Y)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
