### PR TITLE
[KAN-37] daily todo change status

### DIFF
--- a/src/hb-backend-api/daily-todo/adapters/in/dto/update-daily-todo-complete-status.dto.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/dto/update-daily-todo-complete-status.dto.ts
@@ -1,0 +1,12 @@
+import { DailyTodoCompleteStatus } from "../../../domain/enums/daily-todo-complete-status.enum";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsNotEmpty } from "class-validator";
+
+export class UpdateDailyTodoCompleteStatusDto {
+  @ApiProperty({ type: "string", required: true })
+  @IsEnum(DailyTodoCompleteStatus, {
+    message: "데일리 투두의 진행상태가 유효하지 않아요.",
+  })
+  @IsNotEmpty({ message: "데일리 투두의 진행상태가 없어요." })
+  status: DailyTodoCompleteStatus;
+}

--- a/src/hb-backend-api/daily-todo/adapters/in/dto/update-daily-todo-cycle.dto.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/dto/update-daily-todo-cycle.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsNotEmpty } from "class-validator";
+import { DailyTodoCycle } from "../../../domain/enums/daily-todo-cycle.enum";
+
+export class UpdateDailyTodoCycleDto {
+  @ApiProperty({ type: "string", required: true })
+  @IsEnum(DailyTodoCycle, {
+    message: "데일리 투두의 사이클이 유효하지 않아요.",
+  })
+  @IsNotEmpty({ message: "데일리 투두의 사이클이 없어요." })
+  cycle: DailyTodoCycle;
+}

--- a/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Inject,
   Param,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -30,6 +31,12 @@ import { YearMonthDayString } from "../../../domain/vo/year-month-day-string.vo"
 import { ParseDailyTodoIdPipe } from "../pipe/daily-todo-id.pipe";
 import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
 import { GetDailyTodoUseCase } from "../../../application/ports/in/get-daily-todo.use-case";
+import { UpdateDailyTodoCompleteStatusUseCase } from "../../../application/ports/in/update-daily-todo-complete-status.use-case";
+import { UpdateDailyTodoCompleteStatusDto } from "../dto/update-daily-todo-complete-status.dto";
+import { UpdateDailyTodoCompleteStatusCommand } from "../../../application/command/update-daily-todo-complete-status.command";
+import { UpdateDailyTodoCycleDto } from "../dto/update-daily-todo-cycle.dto";
+import { UpdateDailyTodoCycleUseCase } from "../../../application/ports/in/update-daily-todo-cycle.use-case";
+import { UpdateDailyTodoCycleCommand } from "../../../application/command/update-daily-todo-cycle.command";
 
 @ApiTags("DailyTodos")
 @Controller(`${EndPointPrefixConstant}/daily-todos`)
@@ -43,6 +50,10 @@ export class DailyTodoController {
     private readonly getAllDailyTodoUseCase: GetAllDailyTodoUseCase,
     @Inject(DIToken.DailyTodoModule.GetDailyTodoUseCase)
     private readonly getDailyTodoUseCase: GetDailyTodoUseCase,
+    @Inject(DIToken.DailyTodoModule.UpdateDailyTodoCompleteStatusUseCase)
+    private readonly updateDailyTodoCompleteStatusUseCase: UpdateDailyTodoCompleteStatusUseCase,
+    @Inject(DIToken.DailyTodoModule.UpdateDailyTodoCycleUseCase)
+    private readonly updateDailyTodoCycleUseCase: UpdateDailyTodoCycleUseCase,
   ) {}
 
   @ApiOperation({ description: "데일리 투두 모두 조회" })
@@ -103,6 +114,44 @@ export class DailyTodoController {
         categoryId,
       ),
       user.getId,
+    );
+  }
+
+  @ApiOperation({ description: "데일리 투두 완료 상태 변경" })
+  @UseGuards(JwtAuthGuard)
+  @Patch("/:id/complete-status")
+  public async changeCompleteStatus(
+    @NicknameAndAccessToken() userInfo: TokenUserInformation,
+    @Param("id", ParseDailyTodoIdPipe) id: DailyTodoId,
+    @Body() body: UpdateDailyTodoCompleteStatusDto,
+  ): Promise<void> {
+    const user = await this.getUserByNicknameUseCase.invoke(
+      UserNickname.fromString(userInfo.nickname),
+    );
+
+    await this.updateDailyTodoCompleteStatusUseCase.invoke(
+      id,
+      user.getId,
+      UpdateDailyTodoCompleteStatusCommand.of(body.status),
+    );
+  }
+
+  @ApiOperation({ description: "데일리 투두 완료 상태 변경" })
+  @UseGuards(JwtAuthGuard)
+  @Patch("/:id/cycle-status")
+  public async changeCycleStatus(
+    @NicknameAndAccessToken() userInfo: TokenUserInformation,
+    @Param("id", ParseDailyTodoIdPipe) id: DailyTodoId,
+    @Body() body: UpdateDailyTodoCycleDto,
+  ): Promise<void> {
+    const user = await this.getUserByNicknameUseCase.invoke(
+      UserNickname.fromString(userInfo.nickname),
+    );
+
+    await this.updateDailyTodoCycleUseCase.invoke(
+      id,
+      user.getId,
+      UpdateDailyTodoCycleCommand.of(body.cycle),
     );
   }
 }

--- a/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
@@ -136,7 +136,7 @@ export class DailyTodoController {
     );
   }
 
-  @ApiOperation({ description: "데일리 투두 완료 상태 변경" })
+  @ApiOperation({ description: "데일리 투두 밴벽 저게 변경" })
   @UseGuards(JwtAuthGuard)
   @Patch("/:id/cycle-status")
   public async changeCycleStatus(

--- a/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
@@ -136,7 +136,7 @@ export class DailyTodoController {
     );
   }
 
-  @ApiOperation({ description: "데일리 투두 밴벽 저게 변경" })
+  @ApiOperation({ description: "데일리 투두 반복 주기 변경" })
   @UseGuards(JwtAuthGuard)
   @Patch("/:id/cycle-status")
   public async changeCycleStatus(

--- a/src/hb-backend-api/daily-todo/adapters/out/persistence/daily-todo-persistence.adapter.ts
+++ b/src/hb-backend-api/daily-todo/adapters/out/persistence/daily-todo-persistence.adapter.ts
@@ -3,6 +3,10 @@ import { DailyTodoPersistencePort } from "../../../application/ports/out/daily-t
 import { DIToken } from "../../../../../shared/di/token.di";
 import { DailyTodoRepository } from "../../../domain/repositories/daily-todo.repository";
 import { DailyTodoCreateEntitySchema } from "src/hb-backend-api/daily-todo/domain/entity/daily-todo.entity";
+import { DailyTodoCompleteStatus } from "src/hb-backend-api/daily-todo/domain/enums/daily-todo-complete-status.enum";
+import { DailyTodoCycle } from "src/hb-backend-api/daily-todo/domain/enums/daily-todo-cycle.enum";
+import { DailyTodoId } from "src/hb-backend-api/daily-todo/domain/vo/daily-todo-id.vo";
+import { UserId } from "src/hb-backend-api/user/domain/vo/user-id.vo";
 
 @Injectable()
 export class DailyTodoPersistenceAdapter implements DailyTodoPersistencePort {
@@ -15,5 +19,25 @@ export class DailyTodoPersistenceAdapter implements DailyTodoPersistencePort {
     dailyTodoCreateEntitySchema: DailyTodoCreateEntitySchema,
   ): Promise<void> {
     await this.dailyTodoRepository.save(dailyTodoCreateEntitySchema);
+  }
+
+  public async updateDailyTodoCompleteStatus(
+    id: DailyTodoId,
+    owner: UserId,
+    progress: DailyTodoCompleteStatus,
+  ): Promise<void> {
+    await this.dailyTodoRepository.updateDailyTodoCompleteStatus(
+      id,
+      owner,
+      progress,
+    );
+  }
+
+  public async updateDailyTodoCycle(
+    id: DailyTodoId,
+    owner: UserId,
+    cycle: DailyTodoCycle,
+  ): Promise<void> {
+    await this.dailyTodoRepository.updateDailyTodoCycle(id, owner, cycle);
   }
 }

--- a/src/hb-backend-api/daily-todo/application/command/update-daily-todo-complete-status.command.ts
+++ b/src/hb-backend-api/daily-todo/application/command/update-daily-todo-complete-status.command.ts
@@ -1,0 +1,17 @@
+import { DailyTodoCompleteStatus } from "../../domain/enums/daily-todo-complete-status.enum";
+
+export class UpdateDailyTodoCompleteStatusCommand {
+  constructor(private readonly progress: DailyTodoCompleteStatus) {
+    this.progress = progress;
+  }
+
+  public static of(
+    progress: DailyTodoCompleteStatus,
+  ): UpdateDailyTodoCompleteStatusCommand {
+    return new UpdateDailyTodoCompleteStatusCommand(progress);
+  }
+
+  public get getStatus(): DailyTodoCompleteStatus {
+    return this.progress;
+  }
+}

--- a/src/hb-backend-api/daily-todo/application/command/update-daily-todo-cycle.command.ts
+++ b/src/hb-backend-api/daily-todo/application/command/update-daily-todo-cycle.command.ts
@@ -1,0 +1,15 @@
+import { DailyTodoCycle } from "../../domain/enums/daily-todo-cycle.enum";
+
+export class UpdateDailyTodoCycleCommand {
+  constructor(private readonly cycle: DailyTodoCycle) {
+    this.cycle = cycle;
+  }
+
+  public static of(cycle: DailyTodoCycle): UpdateDailyTodoCycleCommand {
+    return new UpdateDailyTodoCycleCommand(cycle);
+  }
+
+  public get getCycle(): DailyTodoCycle {
+    return this.cycle;
+  }
+}

--- a/src/hb-backend-api/daily-todo/application/ports/in/update-daily-todo-complete-status.use-case.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/in/update-daily-todo-complete-status.use-case.ts
@@ -1,0 +1,11 @@
+import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
+import { UserId } from "../../../../user/domain/vo/user-id.vo";
+import { UpdateDailyTodoCompleteStatusCommand } from "../../command/update-daily-todo-complete-status.command";
+
+export interface UpdateDailyTodoCompleteStatusUseCase {
+  invoke(
+    id: DailyTodoId,
+    owner: UserId,
+    command: UpdateDailyTodoCompleteStatusCommand,
+  ): Promise<void>;
+}

--- a/src/hb-backend-api/daily-todo/application/ports/in/update-daily-todo-cycle.use-case.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/in/update-daily-todo-cycle.use-case.ts
@@ -1,0 +1,11 @@
+import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
+import { UserId } from "../../../../user/domain/vo/user-id.vo";
+import { UpdateDailyTodoCycleCommand } from "../../command/update-daily-todo-cycle.command";
+
+export interface UpdateDailyTodoCycleUseCase {
+  invoke(
+    id: DailyTodoId,
+    owner: UserId,
+    command: UpdateDailyTodoCycleCommand,
+  ): Promise<void>;
+}

--- a/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-persistence.port.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-persistence.port.ts
@@ -1,5 +1,21 @@
 import { DailyTodoCreateEntitySchema } from "../../../domain/entity/daily-todo.entity";
+import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
+import { UserId } from "../../../../user/domain/vo/user-id.vo";
+import { DailyTodoCompleteStatus } from "../../../domain/enums/daily-todo-complete-status.enum";
+import { DailyTodoCycle } from "../../../domain/enums/daily-todo-cycle.enum";
 
 export interface DailyTodoPersistencePort {
   save(dailyTodoCreateEntitySchema: DailyTodoCreateEntitySchema): Promise<void>;
+
+  updateDailyTodoCompleteStatus(
+    id: DailyTodoId,
+    owner: UserId,
+    progress: DailyTodoCompleteStatus,
+  ): Promise<void>;
+
+  updateDailyTodoCycle(
+    id: DailyTodoId,
+    owner: UserId,
+    cycle: DailyTodoCycle,
+  ): Promise<void>;
 }

--- a/src/hb-backend-api/daily-todo/application/result/update-daily-todo-cycle.service.ts
+++ b/src/hb-backend-api/daily-todo/application/result/update-daily-todo-cycle.service.ts
@@ -1,0 +1,54 @@
+import { UpdateDailyTodoCycleUseCase } from "../ports/in/update-daily-todo-cycle.use-case";
+import { Inject, Injectable } from "@nestjs/common";
+import { DIToken } from "../../../../shared/di/token.di";
+import { DailyTodoPersistencePort } from "../ports/out/daily-todo-persistence.port";
+import { TransactionRunner } from "../../../../infra/mongo/transaction/transaction.runner";
+import { UserId } from "src/hb-backend-api/user/domain/vo/user-id.vo";
+import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
+import { UpdateDailyTodoCycleCommand } from "../command/update-daily-todo-cycle.command";
+import { Transactional } from "../../../../infra/mongo/transaction/transaction.decorator";
+import { DailyTodoWithRelationEntity } from "../../domain/entity/daily-todo.retations";
+import { DailyTodoQueryPort } from "../ports/out/daily-todo-query.port";
+import { DailyTodoCycle } from "../../domain/enums/daily-todo-cycle.enum";
+
+@Injectable()
+export class UpdateDailyTodoCycleService
+  implements UpdateDailyTodoCycleUseCase
+{
+  constructor(
+    @Inject(DIToken.DailyTodoModule.DailyTodoPersistencePort)
+    private readonly dailyTodoPersistencePort: DailyTodoPersistencePort,
+    @Inject(DIToken.DailyTodoModule.DailyTodoQueryPort)
+    private readonly dailyTodoQueryPort: DailyTodoQueryPort,
+    public readonly transactionRunner: TransactionRunner,
+  ) {}
+
+  @Transactional()
+  public async invoke(
+    id: DailyTodoId,
+    owner: UserId,
+    command: UpdateDailyTodoCycleCommand,
+  ): Promise<void> {
+    const dailyTodo = await this.getBy(id, owner);
+    await this.changeCycle(
+      dailyTodo.getId,
+      dailyTodo.getOwner.getId,
+      command.getCycle,
+    );
+  }
+
+  private async getBy(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationEntity> {
+    return await this.dailyTodoQueryPort.findById(id, owner);
+  }
+
+  private async changeCycle(
+    id: DailyTodoId,
+    owner: UserId,
+    cycle: DailyTodoCycle,
+  ): Promise<void> {
+    await this.dailyTodoPersistencePort.updateDailyTodoCycle(id, owner, cycle);
+  }
+}

--- a/src/hb-backend-api/daily-todo/application/use-cases/update-daily-todo-complete-status.service.ts
+++ b/src/hb-backend-api/daily-todo/application/use-cases/update-daily-todo-complete-status.service.ts
@@ -1,0 +1,57 @@
+import { UserId } from "src/hb-backend-api/user/domain/vo/user-id.vo";
+import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
+import { UpdateDailyTodoCompleteStatusCommand } from "../command/update-daily-todo-complete-status.command";
+import { UpdateDailyTodoCompleteStatusUseCase } from "../ports/in/update-daily-todo-complete-status.use-case";
+import { Inject, Injectable } from "@nestjs/common";
+import { DailyTodoPersistenceAdapter } from "../../adapters/out/persistence/daily-todo-persistence.adapter";
+import { DIToken } from "../../../../shared/di/token.di";
+import { DailyTodoQueryPort } from "../ports/out/daily-todo-query.port";
+import { DailyTodoWithRelationEntity } from "../../domain/entity/daily-todo.retations";
+import { Transactional } from "../../../../infra/mongo/transaction/transaction.decorator";
+import { TransactionRunner } from "../../../../infra/mongo/transaction/transaction.runner";
+
+@Injectable()
+export class UpdateDailyTodoCompleteStatusService
+  implements UpdateDailyTodoCompleteStatusUseCase
+{
+  constructor(
+    @Inject(DIToken.DailyTodoModule.DailyTodoPersistencePort)
+    private readonly dailyTodoPersistencePort: DailyTodoPersistenceAdapter,
+    @Inject(DIToken.DailyTodoModule.DailyTodoQueryPort)
+    private readonly dailyTodoQueryPort: DailyTodoQueryPort,
+    public readonly transactionRunner: TransactionRunner,
+  ) {}
+
+  @Transactional()
+  public async invoke(
+    id: DailyTodoId,
+    owner: UserId,
+    command: UpdateDailyTodoCompleteStatusCommand,
+  ): Promise<void> {
+    const dailyTodo = await this.getBy(id, owner);
+    await this.changeCompleteStatus(
+      dailyTodo.getId,
+      dailyTodo.getOwner.getId,
+      command,
+    );
+  }
+
+  private async getBy(
+    id: DailyTodoId,
+    owner: UserId,
+  ): Promise<DailyTodoWithRelationEntity> {
+    return await this.dailyTodoQueryPort.findById(id, owner);
+  }
+
+  private async changeCompleteStatus(
+    id: DailyTodoId,
+    owner: UserId,
+    command: UpdateDailyTodoCompleteStatusCommand,
+  ): Promise<void> {
+    await this.dailyTodoPersistencePort.updateDailyTodoCompleteStatus(
+      id,
+      owner,
+      command.getStatus,
+    );
+  }
+}

--- a/src/hb-backend-api/daily-todo/daily-todo.module.ts
+++ b/src/hb-backend-api/daily-todo/daily-todo.module.ts
@@ -11,6 +11,8 @@ import { CreateDailyTodoService } from "./application/use-cases/create-daily-tod
 import { DailyTodoQueryAdapter } from "./adapters/out/query/daily-todo-query.adapter";
 import { GetAllDailyTodoService } from "./application/use-cases/get-all-daily-todo.service";
 import { GetDailyTodoService } from "./application/use-cases/get-daily-todo.service";
+import { UpdateDailyTodoCompleteStatusService } from "./application/use-cases/update-daily-todo-complete-status.service";
+import { UpdateDailyTodoCycleService } from "./application/result/update-daily-todo-cycle.service";
 
 @Module({
   imports: [
@@ -47,6 +49,14 @@ import { GetDailyTodoService } from "./application/use-cases/get-daily-todo.serv
       provide: DIToken.DailyTodoModule.GetDailyTodoUseCase,
       useClass: GetDailyTodoService,
     },
+    {
+      provide: DIToken.DailyTodoModule.UpdateDailyTodoCompleteStatusUseCase,
+      useClass: UpdateDailyTodoCompleteStatusService,
+    },
+    {
+      provide: DIToken.DailyTodoModule.UpdateDailyTodoCycleUseCase,
+      useClass: UpdateDailyTodoCycleService,
+    },
   ],
   controllers: [DailyTodoController],
   exports: [
@@ -57,6 +67,8 @@ import { GetDailyTodoService } from "./application/use-cases/get-daily-todo.serv
     DIToken.DailyTodoModule.CreateDailyTodoUseCase,
     DIToken.DailyTodoModule.GetAllDailyTodoUseCase,
     DIToken.DailyTodoModule.GetDailyTodoUseCase,
+    DIToken.DailyTodoModule.UpdateDailyTodoCompleteStatusUseCase,
+    DIToken.DailyTodoModule.UpdateDailyTodoCycleUseCase,
   ],
 })
 export class DailyTodoModule {}

--- a/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
+++ b/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
@@ -3,6 +3,8 @@ import { UserId } from "../../../user/domain/vo/user-id.vo";
 import type { DailyTodoWithRelations } from "../entity/daily-todo.retations";
 import { YearMonthDayString } from "../vo/year-month-day-string.vo";
 import { DailyTodoId } from "../vo/daily-todo-id.vo";
+import { DailyTodoCompleteStatus } from "../enums/daily-todo-complete-status.enum";
+import { DailyTodoCycle } from "../enums/daily-todo-cycle.enum";
 
 export interface DailyTodoRepository {
   save(dailyTodoCreateSchemaEntity: DailyTodoCreateEntitySchema): Promise<void>;
@@ -16,4 +18,16 @@ export interface DailyTodoRepository {
     id: DailyTodoId,
     owner: UserId,
   ): Promise<DailyTodoWithRelations | null>;
+
+  updateDailyTodoCompleteStatus(
+    id: DailyTodoId,
+    owner: UserId,
+    progress: DailyTodoCompleteStatus,
+  ): Promise<void>;
+
+  updateDailyTodoCycle(
+    id: DailyTodoId,
+    owner: UserId,
+    cycle: DailyTodoCycle,
+  ): Promise<void>;
 }

--- a/src/hb-backend-api/daily-todo/infra/repositories/daily-todo.repository.impl.ts
+++ b/src/hb-backend-api/daily-todo/infra/repositories/daily-todo.repository.impl.ts
@@ -15,6 +15,8 @@ import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
 import { AggregateQuery } from "../../../../infra/mongo/query/aggregate.query";
 import { UserId } from "../../../user/domain/vo/user-id.vo";
 import { MongoSessionContext } from "../../../../infra/mongo/transaction/transaction.context";
+import { DailyTodoCompleteStatus } from "../../domain/enums/daily-todo-complete-status.enum";
+import { DailyTodoCycle } from "../../domain/enums/daily-todo-cycle.enum";
 
 @Injectable()
 export class DailyTodoRepositoryImpl implements DailyTodoRepository {
@@ -96,6 +98,54 @@ export class DailyTodoRepositoryImpl implements DailyTodoRepository {
             { $limit: 1 },
           ])
           .exec(),
+    );
+  }
+
+  public async updateDailyTodoCompleteStatus(
+    id: DailyTodoId,
+    owner: UserId,
+    progress: DailyTodoCompleteStatus,
+  ): Promise<void> {
+    const session = MongoSessionContext.getSession();
+    const cache = this.aggregateQuery.cache;
+    cache.clear();
+    await this.dailyTodoModel.findOneAndUpdate(
+      {
+        _id: id.raw,
+        owner: owner.raw,
+      },
+      {
+        $set: {
+          progress: progress,
+        },
+      },
+      {
+        session: session,
+      },
+    );
+  }
+
+  public async updateDailyTodoCycle(
+    id: DailyTodoId,
+    owner: UserId,
+    cycle: DailyTodoCycle,
+  ): Promise<void> {
+    const session = MongoSessionContext.getSession();
+    const cache = this.aggregateQuery.cache;
+    cache.clear();
+    await this.dailyTodoModel.findOneAndUpdate(
+      {
+        _id: id.raw,
+        owner: owner.raw,
+      },
+      {
+        $set: {
+          cycle: cycle,
+        },
+      },
+      {
+        session: session,
+      },
     );
   }
 }

--- a/src/infra/mongo/query/aggregate.query.ts
+++ b/src/infra/mongo/query/aggregate.query.ts
@@ -47,4 +47,8 @@ export class AggregateQuery<T> {
 
     return result;
   }
+
+  public get cache(): MemoryCache<T | T[]> {
+    return this.memoryCache;
+  }
 }

--- a/src/shared/di/token.di.ts
+++ b/src/shared/di/token.di.ts
@@ -64,5 +64,11 @@ export class DIToken {
       "GetAllDailyTodoUseCase",
     );
     public static GetDailyTodoUseCase = this.register("GetDailyTodoUseCase");
+    public static UpdateDailyTodoCompleteStatusUseCase = this.register(
+      "UpdateDailyTodoCompleteStatusUseCase",
+    );
+    public static UpdateDailyTodoCycleUseCase = this.register(
+      "UpdateDailyTodoCycleUseCase",
+    );
   };
 }

--- a/test/mocks/daily-todo.repository.mock.ts
+++ b/test/mocks/daily-todo.repository.mock.ts
@@ -5,5 +5,7 @@ export function createDailyTodoRepository(): jest.Mocked<DailyTodoRepository> {
     save: jest.fn(),
     findAll: jest.fn(),
     findById: jest.fn(),
+    updateDailyTodoCompleteStatus: jest.fn(),
+    updateDailyTodoCycle: jest.fn(),
   };
 }


### PR DESCRIPTION
## 🚀 Summary

DailyTodo, 완료상태 변경 및 반복주기 변경

- 목적: 기능 추가

---

## 📸 Screenshots / API Contract (옵션)

- <img width="1513" alt="image" src="https://github.com/user-attachments/assets/feb724c0-fa83-4ddc-8deb-87ac7a04fa99" />

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (Y)
- 환경 변수 추가/변경: (Y)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
