### PR TITLE
fix: [KAN-57] user email, daily todo reactionUserId 추가

### DIFF
--- a/src/hb-backend-api/daily-todo/adapters/in/dto/get-daily-todo.dto.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/dto/get-daily-todo.dto.ts
@@ -13,12 +13,17 @@ interface CategoryType {
   title: string;
 }
 
+interface ReactionType {
+  value: string;
+  reactionUserId: string;
+}
+
 export class GetDailyTodoDto {
   constructor(
     private readonly id: string,
     private readonly title: string,
     private readonly date: Date,
-    private readonly reaction: string | null,
+    private readonly reaction: ReactionType | null,
     private readonly progress: DailyTodoCompleteStatus,
     private readonly cycle: DailyTodoCycle,
     private readonly owner: OwnerType,
@@ -49,11 +54,18 @@ export class GetDailyTodoDto {
             id: entity.getCategory.getId.toString(),
             title: entity.getCategory.getTitle,
           };
+    const reaction: ReactionType | null =
+      entity.getReaction == null
+        ? null
+        : {
+            value: entity.getReaction.getValue,
+            reactionUserId: entity.getReaction.getReactionUserId.toString(),
+          };
     return new GetDailyTodoDto(
       entity.getId.toString(),
       entity.getTitle,
       entity.getDate,
-      entity.getReaction,
+      reaction,
       entity.getProgress,
       entity.getCycle,
       owner,

--- a/src/hb-backend-api/daily-todo/adapters/in/dto/update-daily-todo-reaction.dto.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/dto/update-daily-todo-reaction.dto.ts
@@ -6,4 +6,9 @@ export class UpdateDailyTodoReactionDto {
   @IsString({ message: "리액션은 문자열만 가능해요." })
   @IsNotEmpty({ message: "리액션이 존재하지 않아요." })
   reaction: string;
+
+  @ApiProperty({ type: "string", required: true })
+  @IsString({ message: "리액션을 누른 사람의 ID는 문자열 이어야 해요." })
+  @IsNotEmpty({ message: "리액션을 누른 사람이 존재하지 않아요." })
+  reactionUserId: string;
 }

--- a/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
+++ b/src/hb-backend-api/daily-todo/adapters/in/rest/daily-todo.controller.ts
@@ -40,6 +40,8 @@ import { UpdateDailyTodoCycleCommand } from "../../../application/command/update
 import { UpdateDailyTodoReactionDto } from "../dto/update-daily-todo-reaction.dto";
 import { UpdateDailyTodoReactionUseCase } from "../../../application/ports/in/update-daily-todo-reaction.use-case";
 import { UpdateDailyTodoReactionCommand } from "../../../application/command/update-daily-todo-reaction.command";
+import { Reaction } from "../../../domain/entity/daily-todo.retations";
+import { UserId } from "../../../../user/domain/vo/user-id.vo";
 
 @ApiTags("DailyTodos")
 @Controller(`${EndPointPrefixConstant}/daily-todos`)
@@ -172,10 +174,14 @@ export class DailyTodoController {
       UserNickname.fromString(userInfo.nickname),
     );
 
+    const reaction = Reaction.of(
+      body.reaction,
+      UserId.fromString(body.reactionUserId),
+    );
     await this.updateDailyTodoReaction.invoke(
       id,
       user.getId,
-      UpdateDailyTodoReactionCommand.of(body.reaction),
+      UpdateDailyTodoReactionCommand.of(reaction),
     );
   }
 }

--- a/src/hb-backend-api/daily-todo/adapters/out/persistence/daily-todo-persistence.adapter.ts
+++ b/src/hb-backend-api/daily-todo/adapters/out/persistence/daily-todo-persistence.adapter.ts
@@ -7,6 +7,7 @@ import { DailyTodoCompleteStatus } from "src/hb-backend-api/daily-todo/domain/en
 import { DailyTodoCycle } from "src/hb-backend-api/daily-todo/domain/enums/daily-todo-cycle.enum";
 import { DailyTodoId } from "src/hb-backend-api/daily-todo/domain/vo/daily-todo-id.vo";
 import { UserId } from "src/hb-backend-api/user/domain/vo/user-id.vo";
+import { Reaction } from "../../../domain/entity/daily-todo.retations";
 
 @Injectable()
 export class DailyTodoPersistenceAdapter implements DailyTodoPersistencePort {
@@ -44,7 +45,7 @@ export class DailyTodoPersistenceAdapter implements DailyTodoPersistencePort {
   public async updateDailyTodoReaction(
     id: DailyTodoId,
     owner: UserId,
-    reaction: string,
+    reaction: Reaction,
   ): Promise<void> {
     await this.dailyTodoRepository.updateDailyTodoReaction(id, owner, reaction);
   }

--- a/src/hb-backend-api/daily-todo/adapters/out/query/daily-todo-query.adapter.ts
+++ b/src/hb-backend-api/daily-todo/adapters/out/query/daily-todo-query.adapter.ts
@@ -8,6 +8,7 @@ import {
   DailyTodoWithRelationEntity,
   type DailyTodoWithRelations,
   Owner,
+  Reaction,
 } from "../../../domain/entity/daily-todo.retations";
 import { CategoryId } from "../../../../category/domain/vo/category-id.vo";
 import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
@@ -51,7 +52,12 @@ export class DailyTodoQueryAdapter implements DailyTodoQueryPort {
       DailyTodoId.fromString(dailyTodo._id),
       dailyTodo.title,
       dailyTodo.date,
-      dailyTodo.reaction,
+      dailyTodo.reaction == null
+        ? null
+        : Reaction.of(
+            dailyTodo.reaction.value,
+            UserId.fromString(dailyTodo.reaction.reactionUserId),
+          ),
       dailyTodo.progress,
       dailyTodo.cycle,
       Owner.of(

--- a/src/hb-backend-api/daily-todo/application/command/update-daily-todo-reaction.command.ts
+++ b/src/hb-backend-api/daily-todo/application/command/update-daily-todo-reaction.command.ts
@@ -1,13 +1,15 @@
+import { Reaction } from "../../domain/entity/daily-todo.retations";
+
 export class UpdateDailyTodoReactionCommand {
-  constructor(private readonly reaction: string) {
+  constructor(private readonly reaction: Reaction) {
     this.reaction = reaction;
   }
 
-  public static of(reaction: string): UpdateDailyTodoReactionCommand {
+  public static of(reaction: Reaction): UpdateDailyTodoReactionCommand {
     return new UpdateDailyTodoReactionCommand(reaction);
   }
 
-  public get getReaction(): string {
+  public get getReaction(): Reaction {
     return this.reaction;
   }
 }

--- a/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-persistence.port.ts
+++ b/src/hb-backend-api/daily-todo/application/ports/out/daily-todo-persistence.port.ts
@@ -3,6 +3,7 @@ import { DailyTodoId } from "../../../domain/vo/daily-todo-id.vo";
 import { UserId } from "../../../../user/domain/vo/user-id.vo";
 import { DailyTodoCompleteStatus } from "../../../domain/enums/daily-todo-complete-status.enum";
 import { DailyTodoCycle } from "../../../domain/enums/daily-todo-cycle.enum";
+import { Reaction } from "../../../domain/entity/daily-todo.retations";
 
 export interface DailyTodoPersistencePort {
   save(dailyTodoCreateEntitySchema: DailyTodoCreateEntitySchema): Promise<void>;
@@ -22,6 +23,6 @@ export interface DailyTodoPersistencePort {
   updateDailyTodoReaction(
     id: DailyTodoId,
     owner: UserId,
-    reaction: string,
+    reaction: Reaction,
   ): Promise<void>;
 }

--- a/src/hb-backend-api/daily-todo/application/result/daily-todo-query.result.ts
+++ b/src/hb-backend-api/daily-todo/application/result/daily-todo-query.result.ts
@@ -5,6 +5,7 @@ import {
   Category,
   DailyTodoWithRelationEntity,
   Owner,
+  Reaction,
 } from "../../domain/entity/daily-todo.retations";
 
 export class DailyTodoWithRelationQueryResult {
@@ -12,7 +13,7 @@ export class DailyTodoWithRelationQueryResult {
     private readonly id: DailyTodoId,
     private readonly title: string,
     private readonly date: Date,
-    private readonly reaction: string | null,
+    private readonly reaction: Reaction | null,
     private readonly progress: DailyTodoCompleteStatus,
     private readonly cycle: DailyTodoCycle,
     private readonly owner: Owner,
@@ -55,7 +56,7 @@ export class DailyTodoWithRelationQueryResult {
     return this.date;
   }
 
-  public get getReaction(): string | null {
+  public get getReaction(): Reaction | null {
     return this.reaction;
   }
 

--- a/src/hb-backend-api/daily-todo/application/use-cases/update-daily-todo-reaction.service.ts
+++ b/src/hb-backend-api/daily-todo/application/use-cases/update-daily-todo-reaction.service.ts
@@ -8,7 +8,10 @@ import { UpdateDailyTodoReactionCommand } from "../command/update-daily-todo-rea
 import { TransactionRunner } from "../../../../infra/mongo/transaction/transaction.runner";
 import { Transactional } from "../../../../infra/mongo/transaction/transaction.decorator";
 import { DailyTodoQueryPort } from "../ports/out/daily-todo-query.port";
-import { DailyTodoWithRelationEntity } from "../../domain/entity/daily-todo.retations";
+import {
+  DailyTodoWithRelationEntity,
+  Reaction,
+} from "../../domain/entity/daily-todo.retations";
 
 @Injectable()
 export class UpdateDailyTodoReactionService
@@ -46,7 +49,7 @@ export class UpdateDailyTodoReactionService
   private async updateReaction(
     id: DailyTodoId,
     owner: UserId,
-    reaction: string,
+    reaction: Reaction,
   ): Promise<void> {
     await this.dailyTodoPersistencePort.updateDailyTodoReaction(
       id,

--- a/src/hb-backend-api/daily-todo/domain/entity/daily-todo.entity.ts
+++ b/src/hb-backend-api/daily-todo/domain/entity/daily-todo.entity.ts
@@ -28,10 +28,13 @@ export class DailyTodoEntity extends BaseEntity {
   owner: Types.ObjectId;
 
   @Prop({
-    type: String,
+    type: Map,
     default: null,
   })
-  reaction: string;
+  reaction: {
+    value: string;
+    reactionUserId: Types.ObjectId;
+  };
 
   @Prop({
     type: String,

--- a/src/hb-backend-api/daily-todo/domain/entity/daily-todo.retations.ts
+++ b/src/hb-backend-api/daily-todo/domain/entity/daily-todo.retations.ts
@@ -8,7 +8,7 @@ export interface DailyTodoWithRelations {
   _id: string;
   title: string;
   date: Date;
-  reaction: string | null;
+  reaction: { value: string; reactionUserId: string } | null;
   progress: DailyTodoCompleteStatus;
   cycle: DailyTodoCycle;
   owner: {
@@ -72,12 +72,34 @@ export class Category {
   }
 }
 
+export class Reaction {
+  constructor(
+    private readonly value: string,
+    private readonly reactionUserId: UserId,
+  ) {
+    this.value = value;
+    this.reactionUserId = reactionUserId;
+  }
+
+  public static of(value: string, reactionUserId: UserId): Reaction {
+    return new Reaction(value, reactionUserId);
+  }
+
+  public get getValue(): string {
+    return this.value;
+  }
+
+  public get getReactionUserId(): UserId {
+    return this.reactionUserId;
+  }
+}
+
 export class DailyTodoWithRelationEntity {
   constructor(
     private readonly id: DailyTodoId,
     private readonly title: string,
     private readonly date: Date,
-    private readonly reaction: string | null,
+    private readonly reaction: Reaction | null,
     private readonly progress: DailyTodoCompleteStatus,
     private readonly cycle: DailyTodoCycle,
     private readonly owner: Owner,
@@ -97,7 +119,7 @@ export class DailyTodoWithRelationEntity {
     id: DailyTodoId,
     title: string,
     date: Date,
-    reaction: string | null,
+    reaction: Reaction | null,
     progress: DailyTodoCompleteStatus,
     cycle: DailyTodoCycle,
     owner: Owner,
@@ -127,7 +149,7 @@ export class DailyTodoWithRelationEntity {
     return this.date;
   }
 
-  public get getReaction(): string | null {
+  public get getReaction(): Reaction | null {
     return this.reaction;
   }
 

--- a/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
+++ b/src/hb-backend-api/daily-todo/domain/repositories/daily-todo.repository.ts
@@ -1,6 +1,9 @@
 import { DailyTodoCreateEntitySchema } from "../entity/daily-todo.entity";
 import { UserId } from "../../../user/domain/vo/user-id.vo";
-import type { DailyTodoWithRelations } from "../entity/daily-todo.retations";
+import {
+  DailyTodoWithRelations,
+  Reaction,
+} from "../entity/daily-todo.retations";
 import { YearMonthDayString } from "../vo/year-month-day-string.vo";
 import { DailyTodoId } from "../vo/daily-todo-id.vo";
 import { DailyTodoCompleteStatus } from "../enums/daily-todo-complete-status.enum";
@@ -34,6 +37,6 @@ export interface DailyTodoRepository {
   updateDailyTodoReaction(
     id: DailyTodoId,
     owner: UserId,
-    reaction: string,
+    reaction: Reaction,
   ): Promise<void>;
 }

--- a/src/hb-backend-api/daily-todo/infra/repositories/daily-todo.repository.impl.ts
+++ b/src/hb-backend-api/daily-todo/infra/repositories/daily-todo.repository.impl.ts
@@ -8,7 +8,10 @@ import {
 } from "../../domain/entity/daily-todo.entity";
 import { DailyTodoRepository } from "../../domain/repositories/daily-todo.repository";
 import { DailyTodoAggregationHelper } from "../../adapters/out/aggregation/daily-todo-aggregation.helper";
-import type { DailyTodoWithRelations } from "../../domain/entity/daily-todo.retations";
+import {
+  DailyTodoWithRelations,
+  Reaction,
+} from "../../domain/entity/daily-todo.retations";
 import { YearMonthDayString } from "../../domain/vo/year-month-day-string.vo";
 import { DateHelper } from "../../../../shared/date/date.helper";
 import { DailyTodoId } from "../../domain/vo/daily-todo-id.vo";
@@ -152,7 +155,7 @@ export class DailyTodoRepositoryImpl implements DailyTodoRepository {
   public async updateDailyTodoReaction(
     id: DailyTodoId,
     owner: UserId,
-    reaction: string,
+    reaction: Reaction,
   ): Promise<void> {
     const session = MongoSessionContext.getSession();
     const cache = this.aggregateQuery.cache;
@@ -163,7 +166,10 @@ export class DailyTodoRepositoryImpl implements DailyTodoRepository {
       },
       {
         $set: {
-          reaction: reaction,
+          reaction: {
+            value: reaction.getValue,
+            reactionUserId: reaction.getReactionUserId.raw,
+          },
         },
       },
       {

--- a/src/hb-backend-api/user/adapters/in/dto/get-user.dto.ts
+++ b/src/hb-backend-api/user/adapters/in/dto/get-user.dto.ts
@@ -5,11 +5,13 @@ export class GetUserDto {
   constructor(
     private readonly id: string,
     private readonly username: string,
+    private readonly email: string,
     private readonly nickname: string,
     private readonly friends: Types.ObjectId[],
   ) {
     this.id = id;
     this.username = username;
+    this.email = email;
     this.nickname = nickname;
     this.friends = friends;
   }
@@ -18,6 +20,7 @@ export class GetUserDto {
     return new GetUserDto(
       userQueryResult.getId.toString(),
       userQueryResult.getUsername,
+      userQueryResult.getEmail,
       userQueryResult.getNickname,
       userQueryResult.getFriends,
     );

--- a/src/hb-backend-api/user/adapters/out/query/user-query.adapter.ts
+++ b/src/hb-backend-api/user/adapters/out/query/user-query.adapter.ts
@@ -24,6 +24,7 @@ export class UserQueryAdapter implements UserQueryPort {
     return UserEntitySchema.of(
       UserId.fromString(String(foundUser._id)),
       foundUser.username,
+      foundUser.email,
       foundUser.nickname,
       foundUser.password,
       foundUser.friends,
@@ -43,6 +44,7 @@ export class UserQueryAdapter implements UserQueryPort {
     return UserEntitySchema.of(
       UserId.fromString(String(foundUser._id)),
       foundUser.username,
+      foundUser.email,
       foundUser.nickname,
       foundUser.password,
       foundUser.friends,

--- a/src/hb-backend-api/user/application/result/user-query.result.ts
+++ b/src/hb-backend-api/user/application/result/user-query.result.ts
@@ -6,11 +6,13 @@ export class UserQueryResult {
   constructor(
     private readonly id: UserId,
     private readonly username: string,
+    private readonly email: string,
     private readonly nickname: string,
     private readonly friends: Types.ObjectId[],
   ) {
     this.id = id;
     this.username = username;
+    this.email = email;
     this.nickname = nickname;
     this.friends = friends;
   }
@@ -19,6 +21,7 @@ export class UserQueryResult {
     return new UserQueryResult(
       entity.getId,
       entity.getUsername,
+      entity.getEmail,
       entity.getNickname,
       entity.getFriends,
     );
@@ -30,6 +33,10 @@ export class UserQueryResult {
 
   get getUsername(): string {
     return this.username;
+  }
+
+  get getEmail(): string {
+    return this.email;
   }
 
   get getNickname(): string {

--- a/src/hb-backend-api/user/domain/entity/user.entity.ts
+++ b/src/hb-backend-api/user/domain/entity/user.entity.ts
@@ -16,6 +16,13 @@ export class UserEntity extends BaseEntity {
   })
   nickname: string;
 
+  @Prop({
+    type: String,
+    required: true,
+    unique: true,
+  })
+  email: string;
+
   @Prop({ type: String, required: true })
   password: string;
 
@@ -27,12 +34,14 @@ export class UserEntitySchema {
   constructor(
     private readonly id: UserId,
     private readonly username: string,
+    private readonly email: string,
     private readonly nickname: string,
     private readonly password: string,
     private readonly friends: Types.ObjectId[],
   ) {
     this.id = id;
     this.username = username;
+    this.email = email;
     this.nickname = nickname;
     this.password = password;
     this.friends = friends;
@@ -41,6 +50,7 @@ export class UserEntitySchema {
   public static of(
     id: UserId,
     username: string,
+    email: string,
     nickname: string,
     password: string,
     friends?: Types.ObjectId[],
@@ -48,6 +58,7 @@ export class UserEntitySchema {
     return new UserEntitySchema(
       id,
       username,
+      email,
       nickname,
       password,
       friends ?? [],
@@ -60,6 +71,10 @@ export class UserEntitySchema {
 
   get getUsername(): string {
     return this.username;
+  }
+
+  get getEmail(): string {
+    return this.email;
   }
 
   get getNickname(): string {


### PR DESCRIPTION
## 🚀 Summary

user의 email, daily todo reaction user id 추가

- 목적: 리팩토링

---

## 📸 Screenshots / API Contract (옵션)

- (선택 사항) Swagger 변경 요약 / 스크린샷 / Postman 스냅샷 링크 첨부

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (Y)
- 환경 변수 추가/변경: (N)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
