### PR TITLE
feat: [KAN-98] today menu add candidates API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { CategoryModule } from "./hb-backend-api/category/category.module";
 import { AuthModule } from "./hb-backend-api/auth/auth.module";
 import { TransactionModule } from "./infra/mongo/transaction/transaction.module";
 import { MenuRecommendationModule } from "./hb-backend-api/menu-recommendation/menu-recommendation.module";
+import { TodayMenuModule } from "./hb-backend-api/today-menu/today-menu.module";
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { MenuRecommendationModule } from "./hb-backend-api/menu-recommendation/m
     CategoryModule,
     AuthModule,
     MenuRecommendationModule,
+    TodayMenuModule,
     TransactionModule,
   ],
 })

--- a/src/hb-backend-api/today-menu/adapters/in/dto/upsert-today-menu.dto.ts
+++ b/src/hb-backend-api/today-menu/adapters/in/dto/upsert-today-menu.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsOptional, IsString } from "class-validator";
+
+export class UpsertTodayMenuDto {
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  candidates: string[];
+
+  @ApiProperty({ type: String, required: false })
+  @IsOptional()
+  recommendedMenu?: string | null;
+
+  @ApiProperty({ type: String, required: false })
+  @IsOptional()
+  recommendationDate?: string | null;
+
+  @ApiProperty({ type: String, required: false })
+  @IsOptional()
+  todayMenuId?: string | null;
+}

--- a/src/hb-backend-api/today-menu/adapters/in/rest/upsert-today-menu.controller.ts
+++ b/src/hb-backend-api/today-menu/adapters/in/rest/upsert-today-menu.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Inject, Put, UseGuards } from "@nestjs/common";
+import { EndPointPrefixConstant } from "../../../../../shared/constants/end-point-prefix.constant";
+import { JwtAuthGuard } from "../../../../../shared/adpaters/in/rest/guard/jwt-auth.guard";
+import { DIToken } from "../../../../../shared/di/token.di";
+import { UpsertTodayMenuUseCase } from "../../../application/ports/in/upsert-today-menu.use-case";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { UpsertTodayMenuDto } from "../dto/upsert-today-menu.dto";
+import { UpsertTodayMenuCommand } from "../../../application/command/upsert-today-menu.command";
+import { YearMonthDayString } from "../../../../daily-todo/domain/vo/year-month-day-string.vo";
+import { TodayMenuId } from "../../../domain/vo/today-menu.vo";
+import { MenuRecommendationId } from "../../../../menu-recommendation/domain/vo/menu-recommendation-id.vo";
+
+@ApiTags("TodayMenu")
+@Controller(`${EndPointPrefixConstant}/today-menu`)
+export class UpsertTodayMenuController {
+  constructor(
+    @Inject(DIToken.TodayMenuModule.UpsertTodayMenuUseCase)
+    private readonly upsertTodayMenuUseCase: UpsertTodayMenuUseCase,
+  ) {}
+
+  @ApiOperation({
+    summary: "오늘의 메뉴 추첨을 위한 메뉴 등록",
+    description: "오늘의 메뉴 추첨을 위한 메뉴 등록 API",
+  })
+  @UseGuards(JwtAuthGuard)
+  @Put("")
+  public async upsert(@Body() body: UpsertTodayMenuDto): Promise<void> {
+    const command = UpsertTodayMenuCommand.of(
+      body.candidates.map((item) => MenuRecommendationId.fromString(item)),
+      body?.recommendedMenu == null
+        ? null
+        : MenuRecommendationId.fromString(body.recommendedMenu),
+      body?.recommendationDate == null
+        ? null
+        : YearMonthDayString.fromString(body.recommendationDate),
+      body?.todayMenuId == null
+        ? null
+        : TodayMenuId.fromSting(body.todayMenuId),
+    );
+
+    await this.upsertTodayMenuUseCase.invoke(command);
+  }
+}

--- a/src/hb-backend-api/today-menu/adapters/out/persistence/today-menu-persistence.adapter.ts
+++ b/src/hb-backend-api/today-menu/adapters/out/persistence/today-menu-persistence.adapter.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { TodayMenuPersistencePort } from "../../../application/ports/out/today-menu-persistence.port";
+import { DIToken } from "../../../../../shared/di/token.di";
+import { TodayMenuRepository } from "../../../infra/today-menu.repository";
+import { UpsertTodayMenuEntity } from "src/hb-backend-api/today-menu/domain/entity/upsert-today-menu.entity";
+
+@Injectable()
+export class TodayMenuPersistenceAdapter implements TodayMenuPersistencePort {
+  constructor(
+    @Inject(DIToken.TodayMenuModule.TodayMenuRepository)
+    private readonly todayMenuRepository: TodayMenuRepository,
+  ) {}
+
+  public async upsert(entity: UpsertTodayMenuEntity): Promise<void> {
+    await this.todayMenuRepository.upsert(entity);
+  }
+}

--- a/src/hb-backend-api/today-menu/application/command/upsert-today-menu.command.ts
+++ b/src/hb-backend-api/today-menu/application/command/upsert-today-menu.command.ts
@@ -1,0 +1,59 @@
+import { MenuRecommendationId } from "../../../menu-recommendation/domain/vo/menu-recommendation-id.vo";
+import { TodayMenuId } from "../../domain/vo/today-menu.vo";
+import { YearMonthDayString } from "../../../daily-todo/domain/vo/year-month-day-string.vo";
+
+export class UpsertTodayMenuCommand {
+  constructor(
+    private readonly candidates: MenuRecommendationId[],
+    private readonly recommendedMenu: MenuRecommendationId | null,
+    private readonly recommendationDate?: YearMonthDayString | null,
+    private readonly todayMenuId?: TodayMenuId | null,
+  ) {
+    this.candidates = candidates;
+    this.recommendedMenu = recommendedMenu;
+    this.recommendationDate = recommendationDate;
+    this.todayMenuId = todayMenuId;
+  }
+
+  public static of(
+    candidates: MenuRecommendationId[],
+    recommendedMenu: MenuRecommendationId | null,
+    recommendationDate: YearMonthDayString | null,
+    todayMenuId: TodayMenuId | null,
+  ): UpsertTodayMenuCommand {
+    return new UpsertTodayMenuCommand(
+      candidates,
+      recommendedMenu,
+      recommendationDate,
+      todayMenuId,
+    );
+  }
+
+  public get getCandidates(): MenuRecommendationId[] {
+    return this.candidates;
+  }
+
+  public get getRecommendedMenu(): MenuRecommendationId | null {
+    if (this.recommendedMenu == null) {
+      return null;
+    }
+
+    return this.recommendedMenu;
+  }
+
+  public get getRecommendationDate(): YearMonthDayString | null {
+    if (this.recommendationDate == null) {
+      return null;
+    }
+
+    return this.recommendationDate;
+  }
+
+  public get getTodayMenuId(): TodayMenuId | null {
+    if (this.todayMenuId == null) {
+      return null;
+    }
+
+    return this.todayMenuId;
+  }
+}

--- a/src/hb-backend-api/today-menu/application/ports/in/upsert-today-menu.use-case.ts
+++ b/src/hb-backend-api/today-menu/application/ports/in/upsert-today-menu.use-case.ts
@@ -1,0 +1,5 @@
+import { UpsertTodayMenuCommand } from "../../command/upsert-today-menu.command";
+
+export interface UpsertTodayMenuUseCase {
+  invoke(command: UpsertTodayMenuCommand): Promise<void>;
+}

--- a/src/hb-backend-api/today-menu/application/ports/out/today-menu-persistence.port.ts
+++ b/src/hb-backend-api/today-menu/application/ports/out/today-menu-persistence.port.ts
@@ -1,0 +1,5 @@
+import { UpsertTodayMenuEntity } from "../../../domain/entity/upsert-today-menu.entity";
+
+export interface TodayMenuPersistencePort {
+  upsert(entity: UpsertTodayMenuEntity): Promise<void>;
+}

--- a/src/hb-backend-api/today-menu/application/use-cases/upsert-today-menu.service.ts
+++ b/src/hb-backend-api/today-menu/application/use-cases/upsert-today-menu.service.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { UpsertTodayMenuUseCase } from "../ports/in/upsert-today-menu.use-case";
+import { UpsertTodayMenuCommand } from "../command/upsert-today-menu.command";
+import { DIToken } from "../../../../shared/di/token.di";
+import { TodayMenuPersistencePort } from "../ports/out/today-menu-persistence.port";
+import { TransactionRunner } from "../../../../infra/mongo/transaction/transaction.runner";
+import { Transactional } from "../../../../infra/mongo/transaction/transaction.decorator";
+import { UpsertTodayMenuEntity } from "../../domain/entity/upsert-today-menu.entity";
+
+@Injectable()
+export class UpsertTodayMenuService implements UpsertTodayMenuUseCase {
+  constructor(
+    @Inject(DIToken.TodayMenuModule.TodayMenuPersistencePort)
+    private readonly todayMenuPersistencePort: TodayMenuPersistencePort,
+    public readonly transactionRunner: TransactionRunner,
+  ) {}
+
+  @Transactional()
+  public async invoke(command: UpsertTodayMenuCommand): Promise<void> {
+    await this.upsert(command);
+  }
+
+  private async upsert(command: UpsertTodayMenuCommand): Promise<void> {
+    await this.todayMenuPersistencePort.upsert(
+      UpsertTodayMenuEntity.from(command),
+    );
+  }
+}

--- a/src/hb-backend-api/today-menu/domain/entity/today-menu.entity.ts
+++ b/src/hb-backend-api/today-menu/domain/entity/today-menu.entity.ts
@@ -7,6 +7,7 @@ export class TodayMenuEntity extends BaseEntity {
   @Prop({
     type: Types.ObjectId,
     ref: "menu-recommendation",
+    default: null,
   })
   recommendedMenu: Types.ObjectId;
 
@@ -20,6 +21,7 @@ export class TodayMenuEntity extends BaseEntity {
   @Prop({
     type: String,
     required: true,
+    default: null,
   })
   recommendationDate: string;
 }

--- a/src/hb-backend-api/today-menu/domain/entity/upsert-today-menu.entity.ts
+++ b/src/hb-backend-api/today-menu/domain/entity/upsert-today-menu.entity.ts
@@ -1,0 +1,69 @@
+import { MenuRecommendationId } from "../../../menu-recommendation/domain/vo/menu-recommendation-id.vo";
+import { UpsertTodayMenuCommand } from "../../application/command/upsert-today-menu.command";
+import { TodayMenuId } from "../vo/today-menu.vo";
+import { YearMonthDayString } from "../../../daily-todo/domain/vo/year-month-day-string.vo";
+
+export class UpsertTodayMenuEntity {
+  constructor(
+    private readonly candidates: MenuRecommendationId[],
+    private readonly recommendedMenu: MenuRecommendationId | null,
+    private readonly recommendationDate: YearMonthDayString | null,
+    private readonly todayMenuId: TodayMenuId | null,
+  ) {
+    this.candidates = candidates;
+    this.recommendedMenu = recommendedMenu;
+    this.recommendationDate = recommendationDate;
+    this.todayMenuId = todayMenuId;
+  }
+
+  public static of(
+    candidates: MenuRecommendationId[],
+    recommendedMenu: MenuRecommendationId | null,
+    recommendationDate: YearMonthDayString | null,
+    todayMenuId: TodayMenuId | null,
+  ): UpsertTodayMenuEntity {
+    return new UpsertTodayMenuEntity(
+      candidates,
+      recommendedMenu,
+      recommendationDate,
+      todayMenuId,
+    );
+  }
+
+  public static from(command: UpsertTodayMenuCommand): UpsertTodayMenuEntity {
+    return new UpsertTodayMenuEntity(
+      command.getCandidates,
+      command.getRecommendedMenu,
+      command.getRecommendationDate,
+      command.getTodayMenuId,
+    );
+  }
+
+  public get getTodayMenuId(): TodayMenuId | null {
+    if (this.todayMenuId == null) {
+      return null;
+    }
+
+    return this.todayMenuId;
+  }
+
+  public get getRecommendedMenu(): MenuRecommendationId | null {
+    if (this.recommendedMenu == null) {
+      return null;
+    }
+
+    return this.recommendedMenu;
+  }
+
+  public get getCandidates(): MenuRecommendationId[] {
+    return this.candidates;
+  }
+
+  public get getRecommendationDate(): YearMonthDayString | null {
+    if (this.recommendationDate == null) {
+      return null;
+    }
+
+    return this.recommendationDate;
+  }
+}

--- a/src/hb-backend-api/today-menu/domain/repositories/today-menu.repository.impl.ts
+++ b/src/hb-backend-api/today-menu/domain/repositories/today-menu.repository.impl.ts
@@ -1,0 +1,66 @@
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Model } from "mongoose";
+import { TodayMenuRepository } from "../../infra/today-menu.repository";
+import { TodayMenuDocument } from "../entity/today-menu.schema";
+import { TodayMenuEntity } from "../entity/today-menu.entity";
+import { UpsertTodayMenuEntity } from "../entity/upsert-today-menu.entity";
+import { MongoSessionContext } from "../../../../infra/mongo/transaction/transaction.context";
+
+@Injectable()
+export class TodayMenuRepositoryImpl implements TodayMenuRepository {
+  constructor(
+    @InjectModel(TodayMenuEntity.name)
+    private readonly todayMenuModal: Model<TodayMenuDocument>,
+  ) {}
+
+  public async upsert(entity: UpsertTodayMenuEntity): Promise<void> {
+    const session = MongoSessionContext.getSession();
+    const id = entity.getTodayMenuId?.raw;
+
+    if (id == null) {
+      await this.todayMenuModal.create(
+        [
+          {
+            recommendedMenu:
+              entity.getRecommendedMenu?.raw == null
+                ? null
+                : entity.getRecommendedMenu.raw,
+            candidates: entity.getCandidates.map((c) => c.raw),
+            recommendationDate:
+              entity.getRecommendationDate == null
+                ? null
+                : entity.getRecommendationDate.value,
+          },
+        ],
+        {
+          session: session,
+        },
+      );
+    } else {
+      await this.todayMenuModal.findOneAndUpdate(
+        {
+          _id: id,
+        },
+        {
+          $set: {
+            recommendedMenu:
+              entity.getRecommendedMenu?.raw == null
+                ? null
+                : entity.getRecommendedMenu.raw,
+            candidates: entity.getCandidates,
+            recommendationDate:
+              entity.getRecommendationDate == null
+                ? null
+                : entity.getRecommendationDate.value,
+          },
+        },
+        {
+          upsert: true,
+          setDefaultsOnInsert: true,
+          session: session,
+        },
+      );
+    }
+  }
+}

--- a/src/hb-backend-api/today-menu/domain/vo/today-menu.vo.ts
+++ b/src/hb-backend-api/today-menu/domain/vo/today-menu.vo.ts
@@ -1,0 +1,23 @@
+import { Types } from "mongoose";
+
+export class TodayMenuId {
+  constructor(private readonly value: Types.ObjectId) {
+    this.value = value;
+  }
+
+  public static fromSting(id: string): TodayMenuId {
+    if (!Types.ObjectId.isValid(id)) {
+      throw new Error(`Today Menu Id가 유효하지 않아요. ${id}`);
+    }
+
+    return new TodayMenuId(new Types.ObjectId(id));
+  }
+
+  public toString(): string {
+    return this.value.toHexString();
+  }
+
+  public get raw(): Types.ObjectId {
+    return this.value;
+  }
+}

--- a/src/hb-backend-api/today-menu/infra/today-menu.repository.ts
+++ b/src/hb-backend-api/today-menu/infra/today-menu.repository.ts
@@ -1,0 +1,5 @@
+import { UpsertTodayMenuEntity } from "../domain/entity/upsert-today-menu.entity";
+
+export interface TodayMenuRepository {
+  upsert(entity: UpsertTodayMenuEntity): Promise<void>;
+}

--- a/src/hb-backend-api/today-menu/today-menu.module.ts
+++ b/src/hb-backend-api/today-menu/today-menu.module.ts
@@ -3,6 +3,11 @@ import { MongooseModule } from "@nestjs/mongoose";
 import { TodayMenuEntity } from "./domain/entity/today-menu.entity";
 import { TodayMenuSchema } from "./domain/entity/today-menu.schema";
 import { MenuRecommendationModule } from "../menu-recommendation/menu-recommendation.module";
+import { DIToken } from "../../shared/di/token.di";
+import { TodayMenuRepositoryImpl } from "./domain/repositories/today-menu.repository.impl";
+import { TodayMenuPersistenceAdapter } from "./adapters/out/persistence/today-menu-persistence.adapter";
+import { UpsertTodayMenuService } from "./application/use-cases/upsert-today-menu.service";
+import { UpsertTodayMenuController } from "./adapters/in/rest/upsert-today-menu.controller";
 
 @Module({
   imports: [
@@ -14,6 +19,26 @@ import { MenuRecommendationModule } from "../menu-recommendation/menu-recommenda
     ]),
     MenuRecommendationModule,
   ],
-  exports: [MongooseModule],
+  controllers: [UpsertTodayMenuController],
+  providers: [
+    {
+      provide: DIToken.TodayMenuModule.TodayMenuRepository,
+      useClass: TodayMenuRepositoryImpl,
+    },
+    {
+      provide: DIToken.TodayMenuModule.TodayMenuPersistencePort,
+      useClass: TodayMenuPersistenceAdapter,
+    },
+    {
+      provide: DIToken.TodayMenuModule.UpsertTodayMenuUseCase,
+      useClass: UpsertTodayMenuService,
+    },
+  ],
+  exports: [
+    MongooseModule,
+    DIToken.TodayMenuModule.TodayMenuRepository,
+    DIToken.TodayMenuModule.TodayMenuPersistencePort,
+    DIToken.TodayMenuModule.UpsertTodayMenuUseCase,
+  ],
 })
 export class TodayMenuModule {}

--- a/src/shared/di/token.di.ts
+++ b/src/shared/di/token.di.ts
@@ -100,4 +100,16 @@ export class DIToken {
       "FindAllMenuRecommendationUseCase",
     );
   };
+
+  public static readonly TodayMenuModule = class extends DITokenRegister {
+    public static TodayMenuRepository = this.register("TodayMenuRepository");
+
+    public static TodayMenuPersistencePort = this.register(
+      "TodayMenuPersistencePort",
+    );
+
+    public static UpsertTodayMenuUseCase = this.register(
+      "UpsertTodayMenuUseCase",
+    );
+  };
 }

--- a/test/hb-backend-api/menu-recommendation/adapters/out/persistence/menu-recommendation.adapter.spec.ts
+++ b/test/hb-backend-api/menu-recommendation/adapters/out/persistence/menu-recommendation.adapter.spec.ts
@@ -19,7 +19,7 @@ describe("MenuRecommendationAdapter", () => {
   });
 
   describe("save()", () => {
-    it("should call menuRecommendation.save with the given menu recommendation entity", async () => {
+    it("should call menuRecommendationAdapter.save with the given menu recommendation entity", async () => {
       const userId = new UserId(new Types.ObjectId());
       const menuRecommendation = CreateMenuRecommendationEntity.of(
         "menu",

--- a/test/hb-backend-api/today-menu/adapters/out/persistence/today-menu-persistence.adpater.spec.ts
+++ b/test/hb-backend-api/today-menu/adapters/out/persistence/today-menu-persistence.adpater.spec.ts
@@ -1,0 +1,38 @@
+import { Types } from "mongoose";
+import { TodayMenuRepository } from "../../../../../../src/hb-backend-api/today-menu/infra/today-menu.repository";
+import { TodayMenuPersistenceAdapter } from "../../../../../../src/hb-backend-api/today-menu/adapters/out/persistence/today-menu-persistence.adapter";
+import { createTodayMenuRepository } from "../../../../../mocks/today-menu.repository.mock";
+import { UpsertTodayMenuEntity } from "../../../../../../src/hb-backend-api/today-menu/domain/entity/upsert-today-menu.entity";
+import { MenuRecommendationId } from "../../../../../../src/hb-backend-api/menu-recommendation/domain/vo/menu-recommendation-id.vo";
+import { TodayMenuId } from "../../../../../../src/hb-backend-api/today-menu/domain/vo/today-menu.vo";
+import { YearMonthDayString } from "../../../../../../src/hb-backend-api/daily-todo/domain/vo/year-month-day-string.vo";
+
+describe("TodayMenuPersistenceAdapter", () => {
+  let todayMenuRepository: jest.Mocked<TodayMenuRepository>;
+  let todayMenuPersistenceAdapter: TodayMenuPersistenceAdapter;
+
+  beforeEach(() => {
+    todayMenuRepository = createTodayMenuRepository();
+    todayMenuPersistenceAdapter = new TodayMenuPersistenceAdapter(
+      todayMenuRepository,
+    );
+  });
+
+  describe("upsert()", () => {
+    it("should call todayMenuPersistenceAdapter.upsert with the given today menu entity", async () => {
+      const menuId = new MenuRecommendationId(new Types.ObjectId());
+      const todayMenuId = new TodayMenuId(new Types.ObjectId());
+      const todayMenu = UpsertTodayMenuEntity.of(
+        [menuId],
+        menuId,
+        YearMonthDayString.fromString("2025-05-27"),
+        todayMenuId,
+      );
+
+      await todayMenuPersistenceAdapter.upsert(todayMenu);
+
+      expect(todayMenuRepository.upsert).toHaveBeenCalledTimes(1);
+      expect(todayMenuRepository.upsert).toHaveBeenCalledWith(todayMenu);
+    });
+  });
+});

--- a/test/mocks/today-menu.repository.mock.ts
+++ b/test/mocks/today-menu.repository.mock.ts
@@ -1,0 +1,7 @@
+import { TodayMenuRepository } from "../../src/hb-backend-api/today-menu/infra/today-menu.repository";
+
+export function createTodayMenuRepository(): jest.Mocked<TodayMenuRepository> {
+  return {
+    upsert: jest.fn(),
+  };
+}


### PR DESCRIPTION
## 🚀 Summary

Add today menu candidate API

- 목적: 기능 추가

---

## 📸 Screenshots / API Contract (옵션)

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/8bb3fbb0-1a53-41a7-99cc-f9ad15dac42b" />

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (N)
- 환경 변수 추가/변경: (N)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
