### PR TITLE
fix: [KAN-109] 메뉴 추천 오류 수정

### DIFF
--- a/src/hb-backend-api/today-menu/adapters/out/query/today-menu-query.adapter.ts
+++ b/src/hb-backend-api/today-menu/adapters/out/query/today-menu-query.adapter.ts
@@ -37,7 +37,9 @@ export class TodayMenuQueryAdapter implements TodayMenuQueryPort {
   ): TodayMenuRelationEntity {
     return TodayMenuRelationEntity.of(
       TodayMenuId.fromSting(entity.id),
-      this.toMenuRecommendation(entity.recommendedMenu),
+      entity.recommendedMenu?.id == null
+        ? null
+        : this.toMenuRecommendation(entity.recommendedMenu),
       entity.candidates.map(this.toMenuRecommendation),
       YearMonthDayString.fromString(entity.recommendationDate),
     );

--- a/src/hb-backend-api/today-menu/application/use-cases/find-today-menu-by-id.service.ts
+++ b/src/hb-backend-api/today-menu/application/use-cases/find-today-menu-by-id.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { FindTodayMenuByIdUseCase } from "../ports/in/find-today-menu-by-id.use-case";
 import { DIToken } from "../../../../shared/di/token.di";
 import { TodayMenuQueryPort } from "../ports/out/today-menu-query.port";
@@ -31,6 +31,9 @@ export class FindTodayMenuByIdService implements FindTodayMenuByIdUseCase {
     entity: TodayMenuRelationEntity,
   ): GetTodayMenuQueryResult {
     const recommendedMenu = entity.getRecommendedMenu;
+    if (recommendedMenu == null) {
+      throw new NotFoundException("찾으려는 메뉴가 존재하지 않아요.");
+    }
     const candidatesMenu = entity.getCandidates;
     return GetTodayMenuQueryResult.of(
       entity.getId,

--- a/src/hb-backend-api/today-menu/domain/entity/today-menu-with-relations.entity.ts
+++ b/src/hb-backend-api/today-menu/domain/entity/today-menu-with-relations.entity.ts
@@ -31,7 +31,7 @@ export class TodayMenuWithRelationsEntity {
 export class TodayMenuRelationEntity {
   constructor(
     private readonly id: TodayMenuId,
-    private readonly recommendedMenu: MenuRecommendationRelationEntity,
+    private readonly recommendedMenu: MenuRecommendationRelationEntity | null,
     private readonly candidates: MenuRecommendationRelationEntity[],
     private readonly recommendationDate: YearMonthDayString,
   ) {
@@ -43,7 +43,7 @@ export class TodayMenuRelationEntity {
 
   public static of(
     id: TodayMenuId,
-    recommendedMenu: MenuRecommendationRelationEntity,
+    recommendedMenu: MenuRecommendationRelationEntity | null,
     candidates: MenuRecommendationRelationEntity[],
     recommendationDate: YearMonthDayString,
   ): TodayMenuRelationEntity {
@@ -59,7 +59,10 @@ export class TodayMenuRelationEntity {
     return this.id;
   }
 
-  public get getRecommendedMenu(): MenuRecommendationRelationEntity {
+  public get getRecommendedMenu(): MenuRecommendationRelationEntity | null {
+    if (this.recommendedMenu == null) {
+      return null;
+    }
     return this.recommendedMenu;
   }
 

--- a/test/hb-backend-api/today-menu/adapters/out/query/today-menu-query.adapter.spec.ts
+++ b/test/hb-backend-api/today-menu/adapters/out/query/today-menu-query.adapter.spec.ts
@@ -51,10 +51,10 @@ describe("TodayMenuQueryAdapter", () => {
     const result = await todayMenuQueryAdapter.findById(todayMenuId);
 
     expect(result.getId.toString()).toBe(todayMenuId.toString());
-    expect(result.getRecommendedMenu.getId.toString()).toBe(
+    expect(result.getRecommendedMenu?.getId.toString()).toBe(
       menuRecommendationId.toString(),
     );
-    expect(result.getRecommendedMenu.getName).toBe("FoodName");
+    expect(result.getRecommendedMenu?.getName).toBe("FoodName");
     expect(result.getCandidates.length).toBe(1);
     expect(result.getRecommendationDate.value).toBe("2025-06-07");
   });


### PR DESCRIPTION
## 🚀 Summary

메뉴 추첨 이전에 추천된 메뉴가 null 일 수 있음.
이러한 과정에서 findById시 에러 발생

- 목적: 버그 수정

---

## 📸 Screenshots / API Contract (옵션)

- 

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (N)
- 환경 변수 추가/변경: (N)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
